### PR TITLE
use full path for the installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A superlight HTTP fileserver with customizable behavior.
 ## Installation
 
 ```
-go get -u github.com/ViBiOh/viws/cmd
+go get -u github.com/ViBiOh/viws/cmd/viws
 ```
 
 ## Usage


### PR DESCRIPTION
When using the current link, we get that message : 

```
> go get -u  github.com/ViBiOh/viws/cmd
package github.com/ViBiOh/viws/cmd: no Go files in /Users/simon/code/go/src/github.com/ViBiOh/viws/cmd
```